### PR TITLE
Port to recent Haskell ecosystem

### DIFF
--- a/zombie-trellys/.gitignore
+++ b/zombie-trellys/.gitignore
@@ -1,0 +1,3 @@
+/.cabal-sandbox/
+/.stack-work/
+/cabal.sandbox.config

--- a/zombie-trellys/stack.yaml
+++ b/zombie-trellys/stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-9.0
+
+packages:
+  - location: .

--- a/zombie-trellys/trellys-core.cabal
+++ b/zombie-trellys/trellys-core.cabal
@@ -8,7 +8,8 @@ Cabal-Version: >= 1.2
 Build-type: Simple
 tested-with: GHC == 7.2.1
            , GHC == 7.0.4
-			  , GHC == 7.6.1
+           , GHC == 7.6.1
+           , GHC == 8.0.1
          --, GHC == 7.4.1
 
 library
@@ -25,12 +26,12 @@ executable trellys
                  parsec >= 3.1 && < 3.2,
                  pretty >= 1.0.1.0,
                  RepLib >= 0.5.3 && < 0.6, 
-                 unbound >= 0.4.3 && < 0.5,
+                 unbound >= 0.4.3 && < 0.6,
                  mtl,
                  -- 0.2.2.0, 0.3.0.0
                  transformers,
                  array >= 0.3.0.2 && < 0.6,
-                 binary >= 0.7.1 && < 0.8,
+                 binary >= 0.7.1 && < 0.9,
                  unix >= 2.6.0,
                  bytestring >= 0.10,
                  containers,
@@ -38,7 +39,7 @@ executable trellys
                  filepath,
                  HUnit,
                  QuickCheck,
-                 bimap == 0.2.4,
+                 bimap < 0.4,
                  ansi-terminal >= 0.6 && <0.7,
                  fingertree-psqueue >= 0.3 && <0.4
 


### PR DESCRIPTION
This patch
* bumps package version constraints
* adds `stack.yaml` for convenience
* adds `.gitignore`